### PR TITLE
fix: explicitly define function's output to boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Sample output in `/etc/bird/birdwatcher.conf` if `haproxy_check.sh` checks out w
 
 ```
 # DO NOT EDIT MANUALLY
-function match_route()
+function match_route() -> bool
 {
 	return net ~ [
 		192.168.0.0/24,
@@ -45,7 +45,7 @@ As soon as birdwatcher finds out haproxy is down, it will change the content in 
 
 ```
 # DO NOT EDIT MANUALLY
-function match_route()
+function match_route() -> bool
 {
 	return false;
 }

--- a/birdwatcher/templates/function.tpl
+++ b/birdwatcher/templates/function.tpl
@@ -1,4 +1,4 @@
-function {{.FunctionName}}()
+function {{.FunctionName}}() -> bool
 {
 {{- with .Prefixes}}
 	return net ~ [

--- a/birdwatcher/testdata/bird/config
+++ b/birdwatcher/testdata/bird/config
@@ -1,5 +1,5 @@
 # DO NOT EDIT MANUALLY
-function match_route()
+function match_route() -> bool
 {
 	return net ~ [
 		1.2.3.4/32,

--- a/birdwatcher/testdata/bird/config_empty
+++ b/birdwatcher/testdata/bird/config_empty
@@ -1,5 +1,5 @@
 # DO NOT EDIT MANUALLY
-function match_route()
+function match_route() -> bool
 {
 	return false;
 }

--- a/birdwatcher/testdata/prefixset/function_name
+++ b/birdwatcher/testdata/prefixset/function_name
@@ -1,4 +1,4 @@
-function something_else()
+function something_else() -> bool
 {
 	return net ~ [
 		1.2.3.4/32,

--- a/birdwatcher/testdata/prefixset/some_prefixes
+++ b/birdwatcher/testdata/prefixset/some_prefixes
@@ -1,4 +1,4 @@
-function foobar()
+function foobar() -> bool
 {
 	return net ~ [
 		1.2.3.4/32,


### PR DESCRIPTION
bird2 complains about function's output if its not set:
`/etc/bird.d/match_route.conf:4:14: Inferring function match_route return type from its return value: bool`

explicitly defining it prevents unnecessary warning:
https://gitlab.nic.cz/labs/bird/-/blob/v2.14/filter/config.Y?ref_type=tags#L1020