### PR TITLE
Add new parameter 'enablePrefixFilter'

### DIFF
--- a/birdwatcher/config.go
+++ b/birdwatcher/config.go
@@ -111,6 +111,9 @@ func ReadConfig(conf *Config, configFile string) error {
 			allPrefixes[ipn.String()] = true
 		}
 
+		// TODO: How to make it true by default, if toml.DecodeFile set boolean to false by default ?
+		s.enablePrefixFilter = true
+
 		// map name to each search
 		conf.Services[name] = s
 	}

--- a/birdwatcher/config_test.go
+++ b/birdwatcher/config_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"testing"
 	"time"
+	"fmt"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/birdwatcher/healthcheck.go
+++ b/birdwatcher/healthcheck.go
@@ -216,20 +216,20 @@ func (h *HealthCheck) applyConfig(config Config, prefixes PrefixCollection) erro
 }
 
 func (h *HealthCheck) addPrefix(svc *ServiceCheck, prefix net.IPNet) {
-	h.ensurePrefixSet(svc.FunctionName)
+	h.ensurePrefixSet(svc.FunctionName, svc.enablePrefixFilter)
 
 	h.prefixes[svc.FunctionName].Add(prefix)
 	prefixStateMetric.WithLabelValues(svc.Name(), prefix.String()).Set(1.0)
 }
 
 func (h *HealthCheck) removePrefix(svc *ServiceCheck, prefix net.IPNet) {
-	h.ensurePrefixSet(svc.FunctionName)
+	h.ensurePrefixSet(svc.FunctionName, svc.enablePrefixFilter)
 
 	h.prefixes[svc.FunctionName].Remove(prefix)
 	prefixStateMetric.WithLabelValues(svc.Name(), prefix.String()).Set(0.0)
 }
 
-func (h *HealthCheck) ensurePrefixSet(functionName string) {
+func (h *HealthCheck) ensurePrefixSet(functionName string, enablePrefixFilter bool) {
 	// make sure the top level map is prepared
 	if h.prefixes == nil {
 		h.prefixes = make(PrefixCollection)
@@ -237,7 +237,7 @@ func (h *HealthCheck) ensurePrefixSet(functionName string) {
 
 	// make sure a mapping for this function name exists
 	if _, found := h.prefixes[functionName]; !found {
-		h.prefixes[functionName] = NewPrefixSet(functionName)
+		h.prefixes[functionName] = NewPrefixSet(functionName, enablePrefixFilter)
 	}
 }
 

--- a/birdwatcher/prefixset.go
+++ b/birdwatcher/prefixset.go
@@ -14,18 +14,24 @@ type PrefixCollection map[string]*PrefixSet
 
 // PrefixSet represents a list of prefixes alongside a function name
 type PrefixSet struct {
-	prefixes     []net.IPNet
-	functionName string
+	prefixes           []net.IPNet
+	enablePrefixFilter bool
+	functionName       string
 }
 
 // NewPrefixSet returns a new prefixset with given function name
-func NewPrefixSet(functionName string) *PrefixSet {
-	return &PrefixSet{functionName: functionName}
+func NewPrefixSet(functionName string, enablePrefixFilter bool) *PrefixSet {
+	return &PrefixSet{functionName: functionName, prefixes: make([]net.IPNet, 0), enablePrefixFilter: enablePrefixFilter}
 }
 
 // FunctionName returns the function name
 func (p PrefixSet) FunctionName() string {
 	return p.functionName
+}
+
+// EnablePrefixFilter returns if we should filter `net` with the prefixes, or just return true/false
+func (p PrefixSet) EnablePrefixFilter() bool {
+	return p.enablePrefixFilter
 }
 
 // Prefixes returns the prefixes

--- a/birdwatcher/prefixset_test.go
+++ b/birdwatcher/prefixset_test.go
@@ -10,7 +10,7 @@ import (
 func TestPrefixSet_Add(t *testing.T) {
 	t.Parallel()
 
-	p := NewPrefixSet("foobar")
+	p := NewPrefixSet("foobar", true)
 	// should be empty
 	assert.Empty(t, p.prefixes)
 
@@ -44,7 +44,7 @@ func TestPrefixSet_Add(t *testing.T) {
 func TestPrefixSet_Remove(t *testing.T) {
 	t.Parallel()
 
-	p := NewPrefixSet("foobar")
+	p := NewPrefixSet("foobar", true)
 
 	// add some prefixes
 	prefixes := make([]net.IPNet, 4)

--- a/birdwatcher/servicecheck.go
+++ b/birdwatcher/servicecheck.go
@@ -89,7 +89,7 @@ type ServiceCheck struct {
 	//nolint:revive // these prefixes are converted into net.IPNet
 	prefixes           []net.IPNet
 	state              ServiceState
-	disablePrefixCheck bool
+	enablePrefixFilter bool
 	stopped            chan any
 }
 

--- a/birdwatcher/servicecheck_test.go
+++ b/birdwatcher/servicecheck_test.go
@@ -13,7 +13,6 @@ func TestServiceCheckPushChannel(t *testing.T) {
 
 	buf := make(chan *Action)
 	sc := ServiceCheck{
-		disablePrefixCheck: true,
 		name:               "test",
 		Command:            "/usr/bin/true",
 		Fail:               3,

--- a/birdwatcher/templates/functions.tpl
+++ b/birdwatcher/templates/functions.tpl
@@ -2,14 +2,23 @@
 {{- range .Collections }}
 function {{.FunctionName}}(){{- if not $.CompatBird213 }} -> bool{{- end }}
 {
+{{- if .EnablePrefixFilter }}
 {{- with .Prefixes}}
 	return net ~ [
 {{- range prefixPad . }}
 		{{.}}
-{{- end }}
+{{- end }}{{/* end of range prefixPad */}}
 	];
 {{- else }}
 	return false;
 {{- end }}
-}
+{{- else }}{{/* else of if .enablePrefixFilter */}}
+{{- with .Prefixes}}
+	return true;
+{{- else }}
+	return false;
 {{- end }}
+
+{{- end }}{{/* end of if .enablePrefixFilter */}}
+}
+{{- end }}{{/* end of range .Collections */}}

--- a/birdwatcher/testdata/bird/config_return_true
+++ b/birdwatcher/testdata/bird/config_return_true
@@ -1,0 +1,5 @@
+# DO NOT EDIT MANUALLY
+function match_route() -> bool
+{
+	return true;
+}


### PR DESCRIPTION
 If set to false the the generated function only return true or false with no prefixes filtering

Fix https://github.com/skoef/birdwatcher/issues/28

**I still did not find a way to have a boolean value that defaults to true** when absent from the config file, but can also be overridden to false if need be  
That way it conserve the previous behaviour, which is more safe because it include a prefix checks
But if somebody wants to do a custom check in their bird.conf, they can set `enablePrefixFilter` to false and they will just get a true/false from the generated function. 